### PR TITLE
fix: gitlab pipeline env vars are optional

### DIFF
--- a/library/otel_traces_detector_gitlab_ci.sh
+++ b/library/otel_traces_detector_gitlab_ci.sh
@@ -19,14 +19,25 @@
 
 log_info "Detected, Gitlab CI..."
 
-return_spaces_to_dashes "${CI_PROJECT_URL}-pipelines" "OTEL_SERVICE_NAME"
+if [ -z "${OTEL_SERVICE_NAME-}" }; then
+    return_spaces_to_dashes "${CI_PROJECT_URL}-pipelines" "OTEL_SERVICE_NAME"
+fi
 
-detector_resource_attributes=(
+if [ -n "${detector_resource_attributes-}" ]; then
+    detector_resource_attributes=()
+fi
+
+detector_resource_attributes+=(
   "gitlab.ci.branch:${CI_COMMIT_REF_NAME}"
   "gitlab.ci.build.number:${CI_PIPELINE_ID}"
   "gitlab.ci.build.url:${CI_PIPELINE_URL}"
-  "gitlab.ci.pull.request.branch:${CI_MERGE_REQUEST_SOURCE_BRANCH_NAME}"
-  "gitlab.ci.pull.request.number:${CI_MERGE_REQUEST_ID}"
-  "gitlab.ci.pull.request.repo:${CI_MERGE_REQUEST_SOURCE_PROJECT_PATH}"
   "gitlab.ci.repo:${CI_PROJECT_URL}"
 )
+
+if [ -n "${CI_MERGE_REQUEST_SOURCE_BRANCH_NAME-}" ]; then
+  detector_resource_attributes+=(
+    "gitlab.ci.pull.request.branch:${CI_MERGE_REQUEST_SOURCE_BRANCH_NAME}"
+    "gitlab.ci.pull.request.number:${CI_MERGE_REQUEST_ID}"
+    "gitlab.ci.pull.request.repo:${CI_MERGE_REQUEST_SOURCE_PROJECT_PATH}"
+  )
+fi


### PR DESCRIPTION
I think there are some points which can be improved in the ci scripts (I did only look at GitLab so far, because that's what I am currently using):
* set `service.name` only if not present yet
* append to resource attributes
* add merge requests params only if the pipeline effectively is a merge request

