### PR TITLE
fix: v1 metrics schema with scope metrics

### DIFF
--- a/library/otel_metrics_schema.sh
+++ b/library/otel_metrics_schema.sh
@@ -31,10 +31,10 @@ otel_metrics_resource_metrics=$(cat <<EOF
           {"key":"telemetry.sdk.language","value":{"stringValue":"${telemetry_sdk_lang}"}},
           {"key":"telemetry.sdk.version","value":{"stringValue":"${telemetry_sdk_ver}"}}
         ]
-	},
-      "instrumentationLibraryMetrics": [
+      },
+      "scopeMetrics": [
         {
-          "instrumentationLibrary": {},
+          "scope": {},
           "metrics": []
         }
       ]
@@ -115,7 +115,7 @@ otel_metrics_add_gauge() {
 EOF
 )
 
-  otel_metrics_resource_metrics=$(jq -r ".resourceMetrics[].instrumentationLibraryMetrics[-1].metrics += [$obj]" <<< "$otel_metrics_resource_metrics")
+  otel_metrics_resource_metrics=$(jq -r ".resourceMetrics[].scopeMetrics[-1].metrics += [$obj]" <<< "$otel_metrics_resource_metrics")
 
 }
 
@@ -151,7 +151,7 @@ otel_metrics_add_gauge_datapoint_int() {
 EOF
 )
 
-  otel_metrics_resource_metrics=$(jq -r ".resourceMetrics[].instrumentationLibraryMetrics[].metrics[-1].gauge.dataPoints += [$obj]" <<< "$otel_metrics_resource_metrics")
+  otel_metrics_resource_metrics=$(jq -r ".resourceMetrics[].scopeMetrics[].metrics[-1].gauge.dataPoints += [$obj]" <<< "$otel_metrics_resource_metrics")
 
 }
 
@@ -187,7 +187,7 @@ otel_metrics_add_gauge_datapoint_double() {
 EOF
 )
 
-  otel_metrics_resource_metrics=$(jq -r ".resourceMetrics[].instrumentationLibraryMetrics[].metrics[-1].gauge.dataPoints += [$obj]" <<< "$otel_metrics_resource_metrics")
+  otel_metrics_resource_metrics=$(jq -r ".resourceMetrics[].scopeMetrics[].metrics[-1].gauge.dataPoints += [$obj]" <<< "$otel_metrics_resource_metrics")
 
 }
 
@@ -220,7 +220,7 @@ otel_metrics_add_sum() {
 EOF
 )
 
-  otel_metrics_resource_metrics=$(jq -r ".resourceMetrics[].instrumentationLibraryMetrics[-1].metrics += [$obj]" <<< "$otel_metrics_resource_metrics")
+  otel_metrics_resource_metrics=$(jq -r ".resourceMetrics[].scopeMetrics[-1].metrics += [$obj]" <<< "$otel_metrics_resource_metrics")
 
 }
 
@@ -250,11 +250,11 @@ otel_metrics_add_sum_datapoint_double() {
 EOF
 )
 
-  otel_metrics_resource_metrics=$(jq -r ".resourceMetrics[].instrumentationLibraryMetrics[].metrics[-1].sum.dataPoints += [$obj]" <<< "$otel_metrics_resource_metrics")
+  otel_metrics_resource_metrics=$(jq -r ".resourceMetrics[].scopeMetrics[].metrics[-1].sum.dataPoints += [$obj]" <<< "$otel_metrics_resource_metrics")
 
 
-  otel_metrics_resource_metrics=$(jq -r ".resourceMetrics[].instrumentationLibraryMetrics[].metrics[-1].sum.aggregationTemporality = \"AGGREGATION_TEMPORALITY_CUMULATIVE\"" <<< "$otel_metrics_resource_metrics")
-  otel_metrics_resource_metrics=$(jq -r ".resourceMetrics[].instrumentationLibraryMetrics[].metrics[-1].sum.isMonotonic = true" <<< "$otel_metrics_resource_metrics")
+  otel_metrics_resource_metrics=$(jq -r ".resourceMetrics[].scopeMetrics[].metrics[-1].sum.aggregationTemporality = \"AGGREGATION_TEMPORALITY_CUMULATIVE\"" <<< "$otel_metrics_resource_metrics")
+  otel_metrics_resource_metrics=$(jq -r ".resourceMetrics[].scopeMetrics[].metrics[-1].sum.isMonotonic = true" <<< "$otel_metrics_resource_metrics")
 
 }
 
@@ -284,9 +284,9 @@ otel_metrics_add_sum_datapoint_int() {
 EOF
 )
 
-  otel_metrics_resource_metrics=$(jq -r ".resourceMetrics[].instrumentationLibraryMetrics[].metrics[-1].sum.dataPoints += [$obj]" <<< "$otel_metrics_resource_metrics")
+  otel_metrics_resource_metrics=$(jq -r ".resourceMetrics[].scopeMetrics[].metrics[-1].sum.dataPoints += [$obj]" <<< "$otel_metrics_resource_metrics")
 
 
-  otel_metrics_resource_metrics=$(jq -r ".resourceMetrics[].instrumentationLibraryMetrics[].metrics[-1].sum.aggregationTemporality = \"AGGREGATION_TEMPORALITY_CUMULATIVE\"" <<< "$otel_metrics_resource_metrics")
-  otel_metrics_resource_metrics=$(jq -r ".resourceMetrics[].instrumentationLibraryMetrics[].metrics[-1].sum.isMonotonic = true" <<< "$otel_metrics_resource_metrics")
+  otel_metrics_resource_metrics=$(jq -r ".resourceMetrics[].scopeMetrics[].metrics[-1].sum.aggregationTemporality = \"AGGREGATION_TEMPORALITY_CUMULATIVE\"" <<< "$otel_metrics_resource_metrics")
+  otel_metrics_resource_metrics=$(jq -r ".resourceMetrics[].scopeMetrics[].metrics[-1].sum.isMonotonic = true" <<< "$otel_metrics_resource_metrics")
 }


### PR DESCRIPTION
`instrumentationLibraryMetrics` is not compatible with the provided [`resourceMetrics`](https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/metrics/v1/metrics.proto#L48) type. it should actually be [`scopeMetrics`](https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/metrics/v1/metrics.proto#L56) instead.

I've noticed it because the open-telemetry collector returned the HTTP 500 code, saying that "the key `resourceMetrics[0].instrumentationLibraryMetrics` is invalid". the shell extension does manage to send metrics to the collector with this schema.