### PR TITLE
Added support for creating span links

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,13 @@ sleep_for() {
 
 # Start a parent span
 otel_trace_start_parent_span sleep_for 1
+
 # Start a child span, associated to the parent
 otel_trace_start_child_span sleep_for 2
+
+# Add a SpanLink
+local linked_span=("$linkedTraceId" "$linkedSpanId" "$linkedTraceState")
+otel_trace_start_child_span sleep_for 3
 
 log_info "TraceId: ${OTEL_TRACE_ID}"
 ```

--- a/library/otel_traces.sh
+++ b/library/otel_traces.sh
@@ -84,6 +84,14 @@ otel_trace_start_parent_span() {
 		otel_trace_add_resourcespan_scopespans_spans_attrib_string "function" "${FUNCNAME[1]}()"
 	fi
 
+  if [ -n "${linked_span-}" ]; then
+    local linkedTraceId=${linked_span[0]}
+    local linkedTraceState=${linked_span[1]}
+    local linkedSpanId=${linked_span[2]}
+    log_debug "linkedTraceId: $linkedTraceId, linkedTraceState: $linkedTraceState, linkedSpanId: $linkedSpanId"
+    otel_trace_add_resourcespan_scopespans_spans_link $linkedTraceId $linkedTraceState $linkedSpanId
+  fi
+
   if [ -z "${OTEL_LOG_LEVEL-}" ]; then
 		log_debug "curling ${OTEL_EXPORTER_OTEL_ENDPOINT}/v1/traces"
     net_client_post "${otel_trace_resource_spans}" "${OTEL_EXPORTER_OTEL_ENDPOINT}/v1/traces"
@@ -162,6 +170,14 @@ otel_trace_start_child_span() {
 	fi
 
   otel_trace_add_resourcespan_scopespans_spans_attrib_string "code.url" "${PWD}/${0##*/}#L${BASH_LINENO[0]}"
+
+  if [ -n "${linked_span-}" ]; then
+    local linkedTraceId=${linked_span[0]}
+    local linkedTraceState=${linked_span[1]}
+    local linkedSpanId=${linked_span[2]}
+    log_debug "linkedTraceId: $linkedTraceId, linkedTraceState: $linkedTraceState, linkedSpanId: $linkedSpanId"
+    otel_trace_add_resourcespan_scopespans_spans_link $linkedTraceId $linkedTraceState $linkedSpanId
+  fi
 
   if [ -z "${OTEL_LOG_LEVEL-}" ]; then
     net_client_post "${otel_trace_resource_spans}" "${OTEL_EXPORTER_OTEL_ENDPOINT}/v1/traces"

--- a/library/otel_traces_schema.sh
+++ b/library/otel_traces_schema.sh
@@ -155,3 +155,24 @@ EOF
 
   otel_trace_resource_spans=$(jq -r ".resourceSpans[].scopeSpans[].spans[-1].attributes += [$attribute]" <<< "$otel_trace_resource_spans")
 }
+
+otel_trace_add_resourcespan_scopespans_spans_link() {
+  local trace_id="${1}"
+  local span_id="${2}"
+  local trace_state=""
+
+  if [ -n "${3-}" ]; then
+    trace_state="${3}"
+  fi
+
+  local link=$(cat <<EOF
+{
+  "trace_id": "$trace_id",
+  "span_id": "$span_id",
+  "trace_state": "$trace_state",
+}
+EOF
+)
+
+  otel_trace_resource_spans=$(jq -r ".resourceSpans[].scopeSpans[].spans[-1].links += [$link]" <<< "$otel_trace_resource_spans")
+}


### PR DESCRIPTION
[Span Links](https://opentelemetry.io/docs/concepts/signals/traces/#span-links) allow one span to be associated with another to identify causal relationships.